### PR TITLE
Title: Fix: move basic sequence analysis logic from main.py to BasicSequenceAnalysis class and add tests (#4)

### DIFF
--- a/src/geneanalyzertool/analysis/basic_analysis.py
+++ b/src/geneanalyzertool/analysis/basic_analysis.py
@@ -1,13 +1,53 @@
 from geneanalyzertool.analysis.analysis import Analysis
 from geneanalyzertool.core.sequences import Sequence, DNA, RNA, Protein
-from typing import Any, override
+from geneanalyzertool.core.file_handler import FileHandler
+from typing import Any, override, List
 
 
 class BasicSequenceAnalysis(Analysis):
     """
     Class for basic analysis performed on dna, rna or protein sequences
-
     """
+
+    def process_sequences(self, sequence_input: str, is_file: bool, seq_type: str, analysis_method: str) -> List[str]:
+        """
+        Process one or more sequences and perform the specified analysis.
+
+        Args:
+            sequence_input: Either a sequence string or file path
+            is_file: Whether sequence_input is a file path
+            seq_type: Type of sequence (DNA, RNA, or Protein)
+            analysis_method: Analysis method to perform
+
+        Returns:
+            List of result strings
+        """
+
+        # Get sequences to analyze
+        if is_file:
+            filehandler = FileHandler()
+            available_sequences, sequence_keys = filehandler.read_in_sequence(sequence_input)
+        else:
+            # Treat the single sequence as a dict with one entry
+            available_sequences = {"input_sequence": sequence_input}
+            sequence_keys = ["input_sequence"]
+
+        # Map sequence type to the appropriate class
+        type_map = {"DNA": DNA, "RNA": RNA, "Protein": Protein}
+        seq_type = type_map[seq_type]
+
+        # Process each sequence
+        results = []
+        for key in sequence_keys:
+            print(f"Analyzing {key}...")
+            sequence_obj = seq_type(available_sequences[key])
+            try:
+                result = self.analyze(sequence_obj, analysis_method)
+                results.append(f"{key}: {result}")
+            except Exception as e:
+                print(f"Error: Analysis interrupted - {e}")
+
+        return results
 
     @override
     def analyze(self, sequence: Sequence, method: str) -> Any:

--- a/src/geneanalyzertool/client/main.py
+++ b/src/geneanalyzertool/client/main.py
@@ -1,7 +1,5 @@
 import argparse
 from geneanalyzertool.analysis.basic_analysis import BasicSequenceAnalysis
-from geneanalyzertool.core.sequences import DNA, RNA, Protein
-from geneanalyzertool.core.file_handler import FileHandler
 
 # if a class is added to this map, --mode in parse_args() must also be updated.
 analysis_map = {
@@ -64,43 +62,38 @@ def parse_args():
 
 def main():
     args = parse_args()
-    analysis_class = analysis_map[args.mode]
-    analyzer = analysis_class()
 
+    # Validate analysis option for the selected mode
     if args.analysis not in analysis_options[args.mode]:
         print(f"Error: Analysis '{args.analysis}' is not valid for mode '{args.mode}'.")
         print(f"Valid options: {analysis_options[args.mode]}")
         exit(1)
 
-    if args.file:
-        filehandler = FileHandler()
-        available_sequences, sequence_keys = filehandler.read_in_sequence(args.sequence)
-    else:
-        # Treat the single sequence as a dict with one entry
-        available_sequences = {"input_sequence": args.sequence}
-        sequence_keys = ["input_sequence"]
+    # Get the appropriate analysis class based on mode
+    analysis_class = analysis_map[args.mode]
+    analyzer = analysis_class()
 
-    results = []
-    for key in sequence_keys:
-        print(f"Analyzing {key}...")
-        type_map = {"DNA": DNA, "RNA": RNA, "Protein": Protein}
-        seq_type = type_map[args.type]
-        sequence_obj = seq_type(available_sequences[key])
+    try:
+        # Delegate sequence processing to the analysis class
+        results = analyzer.process_sequences(
+            sequence_input=args.sequence,
+            is_file=args.file,
+            seq_type=args.type,
+            analysis_method=args.analysis
+        )
 
-        try:
-            result = analyzer.analyze(sequence_obj, args.analysis)
-            results.append(f"{key}: {result}")
-        except Exception as e:
-            print(f"Error: Analysis interrupted - {e}")
-            exit(1)
-
-    if args.out:
-        with open(args.out, 'w') as out_file:
+        # Output results
+        if args.out:
+            with open(args.out, 'w') as out_file:
+                for line in results:
+                    out_file.write(line + "\n")
+        else:
             for line in results:
-                out_file.write(line + "\n")
-    else:
-        for line in results:
-            print(line)
+                print(line)
+
+    except Exception as e:
+        print(f"Error: Analysis interrupted - {e}")
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/analysis/test_basic_sequence_analysis.py
+++ b/tests/analysis/test_basic_sequence_analysis.py
@@ -120,3 +120,57 @@ def test_analyze_invalid_method(analyzer):
     seq = DNA("ATGC")
     with pytest.raises(ValueError):
         analyzer.analyze(seq, "nonExistentMethod")
+
+
+# ---------- process_sequences ----------
+def test_process_sequences_single_sequence(analyzer):
+    results = analyzer.process_sequences(
+        sequence_input="ATGCATGC",
+        is_file=False,
+        seq_type="DNA",
+        analysis_method="gc_percent"
+    )
+
+    assert len(results) == 1
+    assert results[0].startswith("input_sequence:")
+    assert "50.0" in results[0]
+
+
+def test_process_sequences_invalid_analysis_method(analyzer, capsys):
+    results = analyzer.process_sequences(
+        sequence_input="ATGC",
+        is_file=False,
+        seq_type="DNA",
+        analysis_method="invalid_method"
+    )
+
+    # process_sequences should handle the error internally and return no results
+    assert results == []
+    captured = capsys.readouterr()
+    assert "Error: Analysis interrupted" in captured.out
+
+
+def test_process_sequences_rna_translation(analyzer):
+    results = analyzer.process_sequences(
+        sequence_input="AUGUUUUAA",
+        is_file=False,
+        seq_type="RNA",
+        analysis_method="translate"
+    )
+
+    assert len(results) == 1
+    assert results[0].startswith("input_sequence:")
+    assert "MF*" in results[0]
+
+
+def test_process_sequences_type_mismatch(analyzer, capsys):
+    results = analyzer.process_sequences(
+        sequence_input="ATGC",
+        is_file=False,
+        seq_type="DNA",
+        analysis_method="translate"
+    )
+
+    assert results == []
+    captured = capsys.readouterr()
+    assert "Sequence must be of type RNA" in captured.out


### PR DESCRIPTION
# Refactor: move basic sequence analysis logic to class + add tests (Fixes #4)

## Description
This PR resolves #4.

## Changes made
- Moved logic for analysis of basic sequences out of `main.py` and into a new class method called `process_sequences` of the `BasicSequenceAnalysis` class.  
- Added tests for the new `process_sequences` method in `test_basic_sequence_analysis.py`.

## Testing
- All tests passing locally.
